### PR TITLE
Fixes link to first page in pagination

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -23,7 +23,7 @@
 		</li>
 	{% elsif page == 1 %}
 		<li class="pagination-item">
-			<a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="pagination-link"><span class="accessible-name">Strona </span>{{ page }}</a>
+			<a href="{{ '/' | prepend: site.baseurl | replace: '//', '/' }}" class="pagination-link"><span class="accessible-name">Strona </span>{{ page }}</a>
 		</li>
 	{% else %}
 		<li class="pagination-item">


### PR DESCRIPTION
Currently link to first page in pagination leads to previous page instead of first. 

Steps to reproduce:
1. Go to [page 4](https://blog.comandeer.pl/strona-4/)
2. Click on "1" in pagination
3. Oh no! We are on [page 3](https://blog.comandeer.pl/strona-3/)

This commit fixes it.
I hope so, beacuse I've just edited it inline in github editor without any test.